### PR TITLE
Better handling for EDITOR

### DIFF
--- a/conf.d/editor.fish
+++ b/conf.d/editor.fish
@@ -1,0 +1,10 @@
+if type -q nvim
+    set -x EDITOR 'nvim'
+else
+    set -x EDITOR 'vim'
+end
+
+if type -q emacsclient
+    set -x ALTERNATE_EDITOR $EDITOR
+    set -x EDITOR 'emacsclient -c'
+end

--- a/config.fish
+++ b/config.fish
@@ -10,12 +10,6 @@ function fish_greeting
     end
 end
 
-set -x EDITOR 'emacsclient -c'
-if type -q nvim
-    set -x ALTERNATE_EDITOR 'nvim'
-else
-    set -x ALTERNATE_EDITOR 'vim'
-end
 set -x LESS '-R -n -X -m -i -S'
 set -x VIRTUAL_ENV_DISABLE_PROMPT 1
 set -x RIPGREP_CONFIG_PATH $HOME/.config/ripgreprc


### PR DESCRIPTION
ALTERNATE_EDITOR is handled by emacsclient. If it isn't present then we need to use something else