### PR TITLE
WIP: Install fzf using fisher

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,3 +1,4 @@
 fisherman/done
+fisherman/fzf
 fisherman/humanize_duration
 fisherman/z

--- a/functions/fish_user_key_bindings.fish
+++ b/functions/fish_user_key_bindings.fish
@@ -3,6 +3,4 @@ function fish_user_key_bindings
     bind \e\; copy_prev_shell_word
     bind \e\[1\;5C nextd-or-forward-word
     bind \e\[1\;5D prevd-or-backward-word
-
-    type -q fzf_key_bindings; and fzf_key_bindings
 end


### PR DESCRIPTION
`fzf_key_bindings` is bundled with Arch Linux's `fzf` package, and may not be available in other operating systems. The fzf plugin also provides additional key bindings