### PR TITLE
No need to call fzf_key_bindings

### DIFF
--- a/functions/fish_user_key_bindings.fish
+++ b/functions/fish_user_key_bindings.fish
@@ -3,6 +3,4 @@ function fish_user_key_bindings
     bind \e\; copy_prev_shell_word
     bind \e\[1\;5C nextd-or-forward-word
     bind \e\[1\;5D prevd-or-backward-word
-
-    type -q fzf_key_bindings; and fzf_key_bindings
 end


### PR DESCRIPTION
The plugin sets its own key bindings