### PR TITLE
Remove the -c flag from the EDITOR

### DIFF
--- a/conf.d/editor.fish
+++ b/conf.d/editor.fish
@@ -6,5 +6,5 @@ end
 
 if type -q emacsclient
     set -x ALTERNATE_EDITOR $EDITOR
-    set -x EDITOR 'emacsclient -c'
+    set -x EDITOR 'emacsclient'
 end


### PR DESCRIPTION
Some applications treat the entire variable as the program name, even if it contains spaces. This
causes, for example, alt+e not to work in Fish