### PR TITLE
Make sure that `python` points to Python 3 on Mac

### DIFF
--- a/conf.d/path.fish
+++ b/conf.d/path.fish
@@ -1,4 +1,4 @@
 set -U fish_user_paths
-for path in /usr/local/opt/coreutils/libexec/gnubin ~/.cargo/bin ~/.yarn/bin ~/.local/bin
+for path in /usr/local/opt/python/libexec/bin /usr/local/opt/coreutils/libexec/gnubin ~/.cargo/bin ~/.yarn/bin ~/.local/bin
     test -d "$path"; and set -U fish_user_paths "$path" $fish_user_paths
 end


### PR DESCRIPTION
Homebrew allows control to what the `python` binary points to. It does this by placing the
appropriate symlinks in `/usr/local/opt/python/libexec/bin`