### PR TITLE
Set $PATH directly instead of fish_user_paths

### DIFF
--- a/conf.d/path.fish
+++ b/conf.d/path.fish
@@ -1,4 +1,3 @@
-set -U fish_user_paths
 for path in /usr/local/opt/python/libexec/bin /usr/local/opt/coreutils/libexec/gnubin ~/.cargo/bin ~/.yarn/bin ~/.local/bin
-    test -d "$path"; and set -U fish_user_paths "$path" $fish_user_paths
+    test -d "$path"; and set -x PATH "$path" $PATH
 end


### PR DESCRIPTION
According to the documentation it's not recommended to set fish_user_paths in the configuration. It is intended to be set by commands.

https://fishshell.com/docs/current/tutorial.html#tut_path